### PR TITLE
Switched from filewatcher to gaze

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var sendevent = require('sendevent')
   , inject = require('./inject')
   , serve = require('./serve')
   , stack = require('stacked')
-  , filewatcher = require('filewatcher')
+  , Gaze = require('gaze').Gaze
 
 // timestamp to detect server-restarts
 var startup = Date.now()
@@ -45,10 +45,10 @@ module.exports = function(root, opts) {
 
   if (root && watch) {
     var urlsByFile = {}
-      , watcher = filewatcher()
+      , gaze = new Gaze()
 
     // when a file is modifed tell all clients to reload it
-    watcher.on('change', function(file) {
+    gaze.on('changed', function(file) {
       fn.reload(urlsByFile[file])
     })
 
@@ -62,7 +62,7 @@ module.exports = function(root, opts) {
         if (!re.test(path)) return
         urlsByFile[path] = this.path
         this._maxage = 0
-        watcher.add(path)
+        gaze.add(path);
       }}
     })
   }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "tamper": "~0.1.0",
     "stacked": "~1.0.0",
-    "filewatcher": "~1.0.0",
     "send": "~0.1.3",
-    "sendevent": "1.0.0"
+    "sendevent": "1.0.0",
+    "gaze": "~0.5.1"
   },
   "devDependencies": {
     "should": "~1.2.2",


### PR DESCRIPTION
tl;dr - Replaces the filewatcher module with gaze because filewatcher wasn't working for me

Instant seemed like [exactly what I was looking for](https://twitter.com/jeremymorrell/status/450011320255909888) and I eagerly downloaded and tried it. The first change to my CSS file immediately showed up in my browser, and I clapped for joy! Magic! But then subsequent changes didn't have any effect. No!

Updating the file watcher to `gaze` which I'd used in the past and has a lot of community support seemed to fix my issues. I understand this might be a little contentious because `filewatcher` is one of your modules as well. However:
- `gaze` is becoming something of a standard
- is [constantly maintained with many contributors](https://github.com/shama/gaze) across many OSes and used in grunt and gulp
- and has an API that, at least for this project, is basically a one-to-one map to `filewatcher`
