### PR TITLE
watcher on change, added delay option to handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,9 @@ module.exports = function(root, opts) {
 
       // when a file is modifed tell all clients to reload it
       watcher.on('change', function(file) {
-        fn.reload(urlsByFile[file])
+        setTimeout(function(){
+          fn.reload(urlsByFile[file]);
+        }, opts.delay || 0);
       })
 
       // build a RegExp to match all watched file extensions

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+
   "name": "instant",
   "version": "1.8.0",
   "main": "lib",
@@ -25,12 +25,12 @@
     "send": "^0.12.1",
     "sendevent": "^1.0.4",
     "stacked": "^1.1.1",
-    "tamper": "^0.1.0"
+    "tamper": "^0.1.0",
+    "browserify": "^9.0.3"
   },
   "devDependencies": {
     "should": "^5.2.0",
     "supertest": "^0.15.0",
-    "mocha": "^2.2.1",
-    "browserify": "^9.0.3"
+    "mocha": "^2.2.1"
   }
 }


### PR DESCRIPTION
For my current usage I need the option to delay the triggering of reload function. Added an option `delay` that sets the time value on a `setTimeout`.

```js
// when a file is modifed tell all clients to reload it
watcher.on('change', function(file) {
  setTimeout(function(){
    fn.reload(urlsByFile[file]);
  }, opts.delay || 0);
})
```