### PR TITLE
package: Moved browserify from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "send": "^0.12.1",
     "sendevent": "^1.0.4",
     "stacked": "^1.1.1",
-    "tamper": "^0.1.0"
+    "tamper": "^0.1.0",
+    "browserify": "^9.0.3"
   },
   "devDependencies": {
     "should": "^5.2.0",
     "supertest": "^0.15.0",
-    "mocha": "^2.2.1",
-    "browserify": "^9.0.3"
+    "mocha": "^2.2.1"
   }
 }


### PR DESCRIPTION
`bundle.js` is not included in the repo and it depends on browserify, which is only required on dev mode.