### PR TITLE
Graceful shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - lts/*

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var sendevent = require('sendevent')
   , serve = require('./serve')
   , stack = require('stacked')
   , filewatcher = require('filewatcher')
+  , Graceful = require('node-graceful')
 
 // timestamp to detect server-restarts
 var startup = Date.now()
@@ -45,10 +46,11 @@ module.exports = function(root, opts) {
 
     if (root && opts.watch !== false) {
       var urlsByFile = {}
-        , watcher = filewatcher({ delay: opts.delay })
+
+      fn.watcher = filewatcher({ delay: opts.delay })
 
       // when a file is modifed tell all clients to reload it
-      watcher.on('change', function(file) {
+      fn.watcher.on('change', function(file) {
         fn.reload(urlsByFile[file])
       })
 
@@ -62,7 +64,7 @@ module.exports = function(root, opts) {
           if (!re.test(path)) return
           urlsByFile[path] = this.path
           this._maxage = 0
-          watcher.add(path)
+          fn.watcher.add(path)
         }}
       })
     }
@@ -71,6 +73,18 @@ module.exports = function(root, opts) {
   if (root) {
     fn.use(serve(root, opts))
   }
+
+  // Stop the file system watcher so apps can exit gracefully when
+  // terminated by Ctrl+c (SIGINT) or a polite termination request (SIGTERM).
+  // You can also call the cleanUp() function directly to handle housekeeping
+  // in your own server (e.g., when it is asked to close).
+  fn.cleanUp = function (done) {
+    fn.watcher.removeAll()
+    done()
+  }
+  Graceful.timeout = 3000
+  Graceful.on('SIGINT', fn.cleanUp)
+  Graceful.on('SIGTERM', fn.cleanUp)
 
   return fn
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,16 @@ module.exports = function(root, opts) {
         }}
       })
     }
+  } else {
+    // Bypass requested.
+
+    // Create a noop cleanUp() method so that it can be called without
+    // having the calling app having to check for whether we are running
+    // in production mode or not.
+    fn.cleanUp = function (done) {
+      // Do nothing on purpose.
+      done()
+    }
   }
 
   if (root) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,18 @@ module.exports = function(root, opts) {
 
       fn.watcher = filewatcher({ delay: opts.delay })
 
+      // Stop the file system watcher so apps can exit gracefully when
+      // terminated by Ctrl+c (SIGINT) or a polite termination request (SIGTERM).
+      // You can also call the cleanUp() function directly to handle housekeeping
+      // in your own server (e.g., when it is asked to close).
+      fn.cleanUp = function (done) {
+        fn.watcher.removeAll()
+        done()
+      }
+      Graceful.timeout = 3000
+      Graceful.on('SIGINT', fn.cleanUp)
+      Graceful.on('SIGTERM', fn.cleanUp)
+
       // when a file is modifed tell all clients to reload it
       fn.watcher.on('change', function(file) {
         fn.reload(urlsByFile[file])
@@ -73,18 +85,6 @@ module.exports = function(root, opts) {
   if (root) {
     fn.use(serve(root, opts))
   }
-
-  // Stop the file system watcher so apps can exit gracefully when
-  // terminated by Ctrl+c (SIGINT) or a polite termination request (SIGTERM).
-  // You can also call the cleanUp() function directly to handle housekeeping
-  // in your own server (e.g., when it is asked to close).
-  fn.cleanUp = function (done) {
-    fn.watcher.removeAll()
-    done()
-  }
-  Graceful.timeout = 3000
-  Graceful.on('SIGINT', fn.cleanUp)
-  Graceful.on('SIGTERM', fn.cleanUp)
 
   return fn
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "instant",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1353,6 +1353,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-graceful": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-graceful/-/node-graceful-2.0.1.tgz",
+      "integrity": "sha512-5KBFTSSxRV9Qj/3VnJn7JGJBowjd8RfncVfmEjQrh70Jgjp0qxRZlV82TLCt8zLXHtwaY9/FCM4z+XzdvJRw+A=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instant",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "lib",
   "author": "Felix Gnass <fgnass@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "filewatcher": "^3.0.1",
+    "node-graceful": "^2.0.1",
     "send": "^0.17.1",
     "sendevent": "^1.0.4",
     "stacked": "^1.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,12 @@ describe('instant', function() {
       .parse(waitFor(/handleSentEvent/))
       .end(done)
   })
+
+  it('should perform housekeeping when asked', function(done) {
+    ins.cleanUp(function() {
+      done()
+    })
+  })
 })
 
 


### PR DESCRIPTION
Adds `.cleanUp()` method to the instance that removes file system watchers either asked manually or (via the Graceful Shutdown module), when the app is killed.

Please see latest unit test for manual usage example.

With this merge request, `npm test` once again exits at the end of the test run.