### PR TITLE
Add multiple roots

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ var startup = Date.now()
 
 module.exports = function(root, opts) {
 
-  if (typeof root == 'object') {
+  if (typeof root == 'object' && !(root instanceof Array)) {
     opts = root
     root = opts.root
   }
@@ -93,7 +93,15 @@ module.exports = function(root, opts) {
   }
 
   if (root) {
-    fn.use(serve(root, opts))
+    if (root instanceof Array) {
+      // Multiple roots.
+      root.forEach(r => {
+        fn.use(serve(r, Object.create(opts)))
+      })
+    } else {
+      // Single root.
+      fn.use(serve(root, opts))
+    }
   }
 
   return fn


### PR DESCRIPTION
This adds multiple roots support so that you can serve multiple directories under a single mount point (Option 1 in #6).